### PR TITLE
Prevented draw() from overwriting previous selection

### DIFF
--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -187,7 +187,7 @@ public class YSSegmentedControl: UIView {
         selector.backgroundColor = appearance.selectorColor
         addSubview(selector)
         
-        selectItem(at: 0, withAnimation: true)
+        selectItem(at: selectedIndex, withAnimation: true)
         
         setNeedsLayout()
     }


### PR DESCRIPTION
I know this PR into YSSegmentedControl is a bit stale, but I liked the change and made this one more tweak to avoid an issue when changing titles.