### PR TITLE
Add ViewStates, and make scrollable

### DIFF
--- a/YSSegmentedControl.xcodeproj/project.pbxproj
+++ b/YSSegmentedControl.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B28BBFB11BF24CB30064F127 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA61BF24CB30064F127 /* ViewController.swift */; };
+		B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA61BF24CB30064F127 /* TableViewController.swift */; };
 		B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA81BF24CB30064F127 /* AppDelegate.swift */; };
 		B28BBFB31BF24CB30064F127 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B28BBFA91BF24CB30064F127 /* LaunchScreen.xib */; };
 		B28BBFB41BF24CB30064F127 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B28BBFAB1BF24CB30064F127 /* Main.storyboard */; };
@@ -27,7 +27,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		B28BBFA61BF24CB30064F127 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B28BBFA61BF24CB30064F127 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		B28BBFA81BF24CB30064F127 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B28BBFAA1BF24CB30064F127 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		B28BBFAC1BF24CB30064F127 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -61,7 +61,7 @@
 		B28BBFA51BF24CB30064F127 /* Demo */ = {
 			isa = PBXGroup;
 			children = (
-				B28BBFA61BF24CB30064F127 /* ViewController.swift */,
+				B28BBFA61BF24CB30064F127 /* TableViewController.swift */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -234,7 +234,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */,
-				B28BBFB11BF24CB30064F127 /* ViewController.swift in Sources */,
+				B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */,
 				B28BBFB71BF24CB30064F127 /* YSSegmentedControl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -18,6 +18,8 @@ class TableViewController: UITableViewController {
     
     @IBOutlet weak var labelsOnEndsFloatToEdgesSwitch: UISwitch!
     
+    @IBOutlet weak var newTitleTextField: UITextField!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero, titles: [])
@@ -90,5 +92,18 @@ extension TableViewController: YSSegmentedControlDelegate {
     
     func segmentedControl(_ segmentedControl: YSSegmentedControl, didPressItemAt index: Int) {
         print ("[Delegate] segmented did press \(index)")
+    }
+}
+
+extension TableViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+
+        var titles = segmented.titles
+        titles?.append(textField.text ?? "")
+        segmented.titles = titles
+
+        textField.text = ""
+        return true
     }
 }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class TableViewController: UITableViewController {
 
     // MARK: Lifecycle
     
@@ -16,7 +16,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = "Demo"
 
         segmented.frame = CGRect(x: 0, y: 64, width: view.frame.size.width, height: 44)
         segmented.titles = ["First", "Second", "Third"]
@@ -25,7 +24,8 @@ class ViewController: UIViewController {
         }
         
         segmented.delegate = self
-        view.addSubview(segmented)
+
+        navigationItem.titleView = segmented
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController: YSSegmentedControlDelegate {
+extension TableViewController: YSSegmentedControlDelegate {
     func segmentedControl(_ segmentedControl: YSSegmentedControl, willPressItemAt index: Int) {
         print ("[Delegate] segmented will press \(index)")
     }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -9,7 +9,13 @@
 import UIKit
 
 class TableViewController: UITableViewController {
-
+    
+    // MARK: Demo
+    
+    @IBOutlet weak var selectorOffsetFromLabelStepper: UIStepper!
+    @IBOutlet weak var selectorOffsetFromLabelSwitch: UISwitch!
+    @IBOutlet weak var selectorOffsetFromLabelValueLabel: UILabel!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero, titles: [])
@@ -26,6 +32,8 @@ class TableViewController: UITableViewController {
         segmented.delegate = self
 
         navigationItem.titleView = segmented
+        
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
@@ -36,7 +44,16 @@ class TableViewController: UITableViewController {
     
     @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {
         var appearance = segmented.appearance
-        appearance?.selectorOffsetFromLabel = sender.isOn ? 2 : nil
+        appearance?.selectorOffsetFromLabel = sender.isOn ? CGFloat(selectorOffsetFromLabelStepper.value) : nil
+        segmented.appearance = appearance
+    }
+
+    @IBAction func didChageSelectorOffsetFromlabelStepper(_ sender: UIStepper) {
+        selectorOffsetFromLabelSwitch.isOn = true
+        selectorOffsetFromLabelValueLabel.text = "\(sender.value)"
+        
+        var appearance = segmented.appearance
+        appearance?.selectorOffsetFromLabel = CGFloat(sender.value)
         segmented.appearance = appearance
     }
 }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -34,6 +34,10 @@ class TableViewController: UITableViewController {
         navigationItem.titleView = segmented
         
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        
+        selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
+        selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -21,6 +21,9 @@ class TableViewController: UITableViewController {
     @IBOutlet weak var offsetBewteenTitlesStepper: UIStepper!
     @IBOutlet weak var offsetBetweenTitlesValueLabel: UILabel!
     
+    @IBOutlet weak var bottomLineHeightStepper: UIStepper!
+    @IBOutlet weak var bottomLineHeightValueLabel: UILabel!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero)
@@ -78,6 +81,18 @@ class TableViewController: UITableViewController {
         segmented.viewState = viewState
     }
     
+    @IBAction func didChangeBottomLineHeigtStepper(_ sender: UIStepper) {
+        guard sender.value > 0 else {
+            return
+        }
+        
+        bottomLineHeightValueLabel.text = "\(sender.value)"
+        
+        var viewState = segmented.viewState
+        viewState.bottomLineHeight = CGFloat(sender.value)
+        segmented.viewState = viewState
+    }
+    
     // MARK: Helpers
     
     func updateAppearanceConfigurationUI() {
@@ -89,6 +104,9 @@ class TableViewController: UITableViewController {
         
         offsetBewteenTitlesStepper.value = Double(segmented.viewState.offsetBetweenTitles)
         offsetBetweenTitlesValueLabel.text = "\(offsetBewteenTitlesStepper.value)"
+        
+        bottomLineHeightStepper.value = Double(segmented.viewState.bottomLineHeight)
+        bottomLineHeightValueLabel.text = "\(bottomLineHeightStepper.value)"
         
     }
 }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -18,6 +18,9 @@ class TableViewController: UITableViewController {
     
     @IBOutlet weak var newTitleTextField: UITextField!
     
+    @IBOutlet weak var offsetBewteenTitlesStepper: UIStepper!
+    @IBOutlet weak var offsetBetweenTitlesValueLabel: UILabel!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero, titles: [])
@@ -64,6 +67,14 @@ class TableViewController: UITableViewController {
         segmented.appearance = appearance
     }
 
+    @IBAction func didChangeOffsetBetweenTitlesStepper(_ sender: UIStepper) {
+        offsetBetweenTitlesValueLabel.text = "\(sender.value)"
+
+        var appearance = segmented.appearance
+        appearance?.offsetBetweenTitles = CGFloat(sender.value)
+        segmented.appearance = appearance
+    }
+    
     // MARK: Helpers
     
     func updateAppearanceConfigurationUI() {
@@ -72,6 +83,10 @@ class TableViewController: UITableViewController {
         selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
         selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        
+        offsetBewteenTitlesStepper.value = Double(segmented.appearance.offsetBetweenTitles)
+        offsetBetweenTitlesValueLabel.text = "\(offsetBewteenTitlesStepper.value)"
+        
     }
 }
 

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -23,7 +23,7 @@ class TableViewController: UITableViewController {
     
     // MARK: Lifecycle
     
-    let segmented = YSSegmentedControl(frame: .zero, titles: [])
+    let segmented = YSSegmentedControl(frame: .zero)
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -40,9 +40,9 @@ class TableViewController: UITableViewController {
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
-    @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
+    @IBAction func didToggleselectorSpansLabelWidthSwitch(_ sender: UISwitch) {
         var appearance = segmented.appearance
-        appearance?.selectorSpansFullItemWidth = sender.isOn
+        appearance?.selectorSpansLabelWidth = sender.isOn
         segmented.appearance = appearance
     }
     

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -29,17 +29,20 @@ class TableViewController: UITableViewController {
         super.viewDidLoad()
 
         segmented.frame = CGRect(x: 0, y: 64, width: view.frame.size.width, height: 44)
-        segmented.titles = ["First", "Second", "Third"]
+        
+        var viewState = segmented.viewState
+        
+        viewState.titles = ["First", "Second", "Third"]
+        viewState.unselectedTextAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.gray]
+        viewState.selectedTextAttributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.black]
+        
+        segmented.viewState = viewState
+        
         segmented.action = { control, index in
             print ("segmented did pressed \(index)")
         }
         
         segmented.delegate = self
-        
-        var appearance = segmented.appearance
-        appearance?.unselectedTextAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.gray]
-        appearance?.selectedTextAttributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.black]
-        segmented.appearance = appearance
 
         navigationItem.titleView = segmented
         
@@ -49,30 +52,30 @@ class TableViewController: UITableViewController {
     // MARK:- Actions
     
     @IBAction func didTapResetButton(_ sender: UIButton) {
-        segmented.titles = []
+        segmented.viewState = YSSegmentedControlViewState()
     }
     
     @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {
-        var appearance = segmented.appearance
-        appearance?.selectorOffsetFromLabel = sender.isOn ? CGFloat(selectorOffsetFromLabelStepper.value) : nil
-        segmented.appearance = appearance
+        var viewState = segmented.viewState
+        viewState.selectorOffsetFromLabel = sender.isOn ? CGFloat(selectorOffsetFromLabelStepper.value) : nil
+        segmented.viewState = viewState
     }
 
     @IBAction func didChageSelectorOffsetFromlabelStepper(_ sender: UIStepper) {
         selectorOffsetFromLabelSwitch.isOn = true
         selectorOffsetFromLabelValueLabel.text = "\(sender.value)"
         
-        var appearance = segmented.appearance
-        appearance?.selectorOffsetFromLabel = CGFloat(sender.value)
-        segmented.appearance = appearance
+        var viewState = segmented.viewState
+        viewState.selectorOffsetFromLabel = CGFloat(sender.value)
+        segmented.viewState = viewState
     }
 
     @IBAction func didChangeOffsetBetweenTitlesStepper(_ sender: UIStepper) {
         offsetBetweenTitlesValueLabel.text = "\(sender.value)"
 
-        var appearance = segmented.appearance
-        appearance?.offsetBetweenTitles = CGFloat(sender.value)
-        segmented.appearance = appearance
+        var viewState = segmented.viewState
+        viewState.offsetBetweenTitles = CGFloat(sender.value)
+        segmented.viewState = viewState
     }
     
     // MARK: Helpers
@@ -80,11 +83,11 @@ class TableViewController: UITableViewController {
     func updateAppearanceConfigurationUI() {
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
         
-        selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
-        selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
+        selectorOffsetFromLabelStepper.value = Double(segmented.viewState.selectorOffsetFromLabel ?? 0)
+        selectorOffsetFromLabelSwitch.isOn = segmented.viewState.selectorOffsetFromLabel != nil
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
         
-        offsetBewteenTitlesStepper.value = Double(segmented.appearance.offsetBetweenTitles)
+        offsetBewteenTitlesStepper.value = Double(segmented.viewState.offsetBetweenTitles)
         offsetBetweenTitlesValueLabel.text = "\(offsetBewteenTitlesStepper.value)"
         
     }
@@ -104,9 +107,9 @@ extension TableViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
 
-        var titles = segmented.titles
-        titles?.append(textField.text ?? "")
-        segmented.titles = titles
+        var viewState = segmented.viewState
+        viewState.titles.append(textField.text ?? "")
+        segmented.viewState = viewState
 
         textField.text = ""
         return true

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -16,8 +16,6 @@ class TableViewController: UITableViewController {
     @IBOutlet weak var selectorOffsetFromLabelSwitch: UISwitch!
     @IBOutlet weak var selectorOffsetFromLabelValueLabel: UILabel!
     
-    @IBOutlet weak var labelsOnEndsFloatToEdgesSwitch: UISwitch!
-    
     @IBOutlet weak var newTitleTextField: UITextField!
     
     // MARK: Lifecycle
@@ -45,10 +43,10 @@ class TableViewController: UITableViewController {
         updateAppearanceConfigurationUI()
     }
     
-    @IBAction func didToggleselectorSpansLabelWidthSwitch(_ sender: UISwitch) {
-        var appearance = segmented.appearance
-        appearance?.selectorSpansLabelWidth = sender.isOn
-        segmented.appearance = appearance
+    // MARK:- Actions
+    
+    @IBAction func didTapResetButton(_ sender: UIButton) {
+        segmented.titles = []
     }
     
     @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {
@@ -65,12 +63,6 @@ class TableViewController: UITableViewController {
         appearance?.selectorOffsetFromLabel = CGFloat(sender.value)
         segmented.appearance = appearance
     }
-    
-    @IBAction func didToggleLabelsOnEndsFloatToEdgesSwitch(_ sender: UISwitch) {
-        var appearance = segmented.appearance
-        appearance?.labelsOnEndsFloatToEdges = sender.isOn
-        segmented.appearance = appearance
-    }
 
     // MARK: Helpers
     
@@ -80,8 +72,6 @@ class TableViewController: UITableViewController {
         selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
         selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
-        
-        labelsOnEndsFloatToEdgesSwitch.isOn = segmented.appearance.labelsOnEndsFloatToEdges
     }
 }
 

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -44,16 +44,16 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
-                                                    <rect key="frame" x="8" y="8" width="214" height="27.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansLabelWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
+                                                    <rect key="frame" x="8" y="8" width="196.5" height="27.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
                                                     <rect key="frame" x="318" y="6" width="51" height="31"/>
                                                     <connections>
-                                                        <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="S4w-Ka-Spx"/>
+                                                        <action selector="didToggleselectorSpansLabelWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="UuC-Wq-d8y"/>
                                                     </connections>
                                                 </switch>
                                             </subviews>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -6,65 +6,9 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="g39-DK-9tB">
-            <objects>
-                <viewController id="VTR-Tb-F2F" customClass="ViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="LAM-vU-5PP"/>
-                        <viewControllerLayoutGuide type="bottom" id="Bq1-ud-FC4"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="vvK-VF-ak6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AQb-M4-fCx">
-                                <rect key="frame" x="16" y="178" width="214" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2as-26-5uL">
-                                <rect key="frame" x="310" y="173" width="51" height="31"/>
-                                <connections>
-                                    <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="bDR-UU-AIw"/>
-                                </connections>
-                            </switch>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorOffsetFromLabel (2)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zn0-QH-n4o">
-                                <rect key="frame" x="16" y="219" width="216" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-ku-2QY">
-                                <rect key="frame" x="310" y="214" width="51" height="31"/>
-                                <connections>
-                                    <action selector="didToggleSelectorOffsetFromLabelSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="v6N-IX-L65"/>
-                                </connections>
-                            </switch>
-                        </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="zn0-QH-n4o" firstAttribute="leading" secondItem="AQb-M4-fCx" secondAttribute="leading" id="2lH-a0-noH"/>
-                            <constraint firstItem="AQb-M4-fCx" firstAttribute="top" secondItem="LAM-vU-5PP" secondAttribute="bottom" constant="114" id="6Nf-Iz-Fhu"/>
-                            <constraint firstItem="zn0-QH-n4o" firstAttribute="top" secondItem="AQb-M4-fCx" secondAttribute="bottom" constant="20" id="Sj5-if-gop"/>
-                            <constraint firstItem="2as-26-5uL" firstAttribute="centerY" secondItem="AQb-M4-fCx" secondAttribute="centerY" id="SjJ-0v-HDm"/>
-                            <constraint firstItem="xvd-ku-2QY" firstAttribute="trailing" secondItem="2as-26-5uL" secondAttribute="trailing" id="h9W-eC-QeD"/>
-                            <constraint firstItem="xvd-ku-2QY" firstAttribute="centerY" secondItem="zn0-QH-n4o" secondAttribute="centerY" id="ihb-3o-gPU"/>
-                            <constraint firstItem="2as-26-5uL" firstAttribute="trailing" secondItem="vvK-VF-ak6" secondAttribute="trailingMargin" id="owm-e9-8hB"/>
-                            <constraint firstItem="AQb-M4-fCx" firstAttribute="leading" secondItem="vvK-VF-ak6" secondAttribute="leadingMargin" id="rok-g6-kWh"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="OK5-fF-1mM"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="p0I-Kd-0mt" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="481" y="773"/>
-        </scene>
         <!--Navigation Controller-->
         <scene sceneID="3ea-eU-sLf">
             <objects>
@@ -74,12 +18,41 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="VTR-Tb-F2F" kind="relationship" relationship="rootViewController" id="PhC-Qh-ky9"/>
+                        <segue destination="DNs-Uf-ScM" kind="relationship" relationship="rootViewController" id="Ync-ja-EK5"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tZi-Fz-fVn" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-410" y="774"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="gTT-st-N6h">
+            <objects>
+                <tableViewController id="DNs-Uf-ScM" customClass="TableViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="DNs-Uf-ScM" id="47K-WW-Nub"/>
+                            <outlet property="delegate" destination="DNs-Uf-ScM" id="x3p-NO-uE0"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="HIx-N7-63y"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cig-mt-BGt" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="350" y="773"/>
         </scene>
     </scenes>
 </document>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -37,32 +37,26 @@
                         <sections>
                             <tableViewSection id="7eX-e6-5TY">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="am8-Fe-rgG">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="am8-Fe-rgG" id="b1p-Mc-VAH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansLabelWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
-                                                    <rect key="frame" x="8" y="8" width="196.5" height="27.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
-                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jq3-Jk-W2I">
+                                                    <rect key="frame" x="8" y="8" width="359" height="27.5"/>
+                                                    <state key="normal" title="Reset"/>
                                                     <connections>
-                                                        <action selector="didToggleselectorSpansLabelWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="UuC-Wq-d8y"/>
+                                                        <action selector="didTapResetButton:" destination="DNs-Uf-ScM" eventType="touchUpInside" id="MBu-64-igV"/>
                                                     </connections>
-                                                </switch>
+                                                </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="centerY" secondItem="Cj7-PA-8So" secondAttribute="centerY" id="BBJ-wl-qhB"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="Cj7-PA-8So" secondAttribute="bottom" id="Csm-ti-vnT"/>
-                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="top" secondItem="eu6-QD-iyM" secondAttribute="topMargin" id="OqY-z3-Hx4"/>
-                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="leading" secondItem="eu6-QD-iyM" secondAttribute="leadingMargin" id="er7-0P-cZw"/>
-                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="trailing" secondItem="eu6-QD-iyM" secondAttribute="trailingMargin" id="ymo-NR-6Sr"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Jq3-Jk-W2I" secondAttribute="bottom" id="70u-m4-ORf"/>
+                                                <constraint firstItem="Jq3-Jk-W2I" firstAttribute="top" secondItem="b1p-Mc-VAH" secondAttribute="topMargin" id="C4P-MR-Ozj"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Jq3-Jk-W2I" secondAttribute="trailing" id="Ug2-IR-1et"/>
+                                                <constraint firstItem="Jq3-Jk-W2I" firstAttribute="leading" secondItem="b1p-Mc-VAH" secondAttribute="leadingMargin" id="ee2-V2-zNK"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -111,37 +105,8 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Tjf-ch-ALz">
-                                        <rect key="frame" x="0.0" y="120" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Tjf-ch-ALz" id="Akb-0w-Gpf">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="labelsOnEndsFloatToEdges" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q26-Ps-DNw">
-                                                    <rect key="frame" x="8" y="8" width="208.5" height="27.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1rn-n8-Gim">
-                                                    <rect key="frame" x="318" y="6.5" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="didToggleLabelsOnEndsFloatToEdgesSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="A9w-rV-Xcn"/>
-                                                    </connections>
-                                                </switch>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="q26-Ps-DNw" firstAttribute="leading" secondItem="Akb-0w-Gpf" secondAttribute="leadingMargin" id="NYi-ch-X2e"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="q26-Ps-DNw" secondAttribute="bottom" id="bfx-v6-br0"/>
-                                                <constraint firstItem="1rn-n8-Gim" firstAttribute="centerY" secondItem="q26-Ps-DNw" secondAttribute="centerY" id="gEX-lI-J0h"/>
-                                                <constraint firstItem="1rn-n8-Gim" firstAttribute="trailing" secondItem="Akb-0w-Gpf" secondAttribute="trailingMargin" id="iOK-3Y-4oW"/>
-                                                <constraint firstItem="q26-Ps-DNw" firstAttribute="top" secondItem="Akb-0w-Gpf" secondAttribute="topMargin" id="raA-31-shz"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="78" id="SSA-jP-SZZ">
-                                        <rect key="frame" x="0.0" y="164" width="375" height="78"/>
+                                        <rect key="frame" x="0.0" y="120" width="375" height="78"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SSA-jP-SZZ" id="ozb-k0-e3J">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="77.5"/>
@@ -183,7 +148,6 @@
                     </tableView>
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
                     <connections>
-                        <outlet property="labelsOnEndsFloatToEdgesSwitch" destination="1rn-n8-Gim" id="1ca-ga-wCZ"/>
                         <outlet property="newTitleTextField" destination="6fh-Sl-k3T" id="A7J-Gv-0m6"/>
                         <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
                         <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -142,8 +142,45 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="76" id="UYW-Yh-yAy">
+                                        <rect key="frame" x="0.0" y="196" width="375" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="UYW-Yh-yAy" id="nQc-ab-Vbg">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="bottomLineHeight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbk-Dh-JXa">
+                                                    <rect key="frame" x="8" y="8" width="138" height="22"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" stepValue="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="B7B-D7-KVS">
+                                                    <rect key="frame" x="8" y="38.5" width="94" height="29"/>
+                                                    <connections>
+                                                        <action selector="didChangeBottomLineHeigtStepper:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Ba3-Ty-LTm"/>
+                                                    </connections>
+                                                </stepper>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kXB-Ho-zJj">
+                                                    <rect key="frame" x="110" y="43" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="kXB-Ho-zJj" firstAttribute="leading" secondItem="B7B-D7-KVS" secondAttribute="trailing" constant="8" id="8bR-MH-WUL"/>
+                                                <constraint firstItem="Dbk-Dh-JXa" firstAttribute="top" secondItem="nQc-ab-Vbg" secondAttribute="topMargin" id="AHi-va-6bg"/>
+                                                <constraint firstItem="kXB-Ho-zJj" firstAttribute="centerY" secondItem="B7B-D7-KVS" secondAttribute="centerY" id="Muv-Je-Ya0"/>
+                                                <constraint firstItem="B7B-D7-KVS" firstAttribute="top" secondItem="Dbk-Dh-JXa" secondAttribute="bottom" constant="8.5" id="Y6J-4S-GiU"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="B7B-D7-KVS" secondAttribute="bottom" id="bOn-q5-L98"/>
+                                                <constraint firstItem="Dbk-Dh-JXa" firstAttribute="leading" secondItem="nQc-ab-Vbg" secondAttribute="leadingMargin" id="g41-nP-8Zw"/>
+                                                <constraint firstItem="B7B-D7-KVS" firstAttribute="leading" secondItem="nQc-ab-Vbg" secondAttribute="leadingMargin" id="pOd-Q0-3eJ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="78" id="SSA-jP-SZZ">
-                                        <rect key="frame" x="0.0" y="196" width="375" height="78"/>
+                                        <rect key="frame" x="0.0" y="272" width="375" height="78"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SSA-jP-SZZ" id="ozb-k0-e3J">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="77.5"/>
@@ -185,6 +222,8 @@
                     </tableView>
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
                     <connections>
+                        <outlet property="bottomLineHeightStepper" destination="B7B-D7-KVS" id="Acp-vh-Pno"/>
+                        <outlet property="bottomLineHeightValueLabel" destination="kXB-Ho-zJj" id="m6B-33-8lL"/>
                         <outlet property="newTitleTextField" destination="6fh-Sl-k3T" id="A7J-Gv-0m6"/>
                         <outlet property="offsetBetweenTitlesValueLabel" destination="hQV-vD-bPB" id="YyW-DF-c3F"/>
                         <outlet property="offsetBewteenTitlesStepper" destination="8ej-WI-ewh" id="3xN-kl-97F"/>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -105,8 +105,45 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="76" id="Chg-4I-o7m">
+                                        <rect key="frame" x="0.0" y="120" width="375" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Chg-4I-o7m" id="0nq-qN-scY">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="offsetBetweenTitles" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OYx-aw-0Ef">
+                                                    <rect key="frame" x="8" y="8" width="151.5" height="22"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="8ej-WI-ewh">
+                                                    <rect key="frame" x="8" y="38.5" width="94" height="29"/>
+                                                    <connections>
+                                                        <action selector="didChangeOffsetBetweenTitlesStepper:" destination="DNs-Uf-ScM" eventType="valueChanged" id="JbG-Vk-j2t"/>
+                                                    </connections>
+                                                </stepper>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQV-vD-bPB">
+                                                    <rect key="frame" x="110" y="43" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottomMargin" secondItem="8ej-WI-ewh" secondAttribute="bottom" id="6Hw-XL-pOi"/>
+                                                <constraint firstItem="8ej-WI-ewh" firstAttribute="top" secondItem="OYx-aw-0Ef" secondAttribute="bottom" constant="8.5" id="BrI-yE-BVn"/>
+                                                <constraint firstItem="OYx-aw-0Ef" firstAttribute="top" secondItem="0nq-qN-scY" secondAttribute="topMargin" id="CbH-Hk-wfM"/>
+                                                <constraint firstItem="OYx-aw-0Ef" firstAttribute="leading" secondItem="0nq-qN-scY" secondAttribute="leadingMargin" id="Qm2-jj-hGk"/>
+                                                <constraint firstItem="8ej-WI-ewh" firstAttribute="leading" secondItem="0nq-qN-scY" secondAttribute="leadingMargin" id="WZf-ph-Q3b"/>
+                                                <constraint firstItem="hQV-vD-bPB" firstAttribute="leading" secondItem="8ej-WI-ewh" secondAttribute="trailing" constant="8" id="Wdn-QL-vRw"/>
+                                                <constraint firstItem="hQV-vD-bPB" firstAttribute="centerY" secondItem="8ej-WI-ewh" secondAttribute="centerY" id="v3W-DR-IxU"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="78" id="SSA-jP-SZZ">
-                                        <rect key="frame" x="0.0" y="120" width="375" height="78"/>
+                                        <rect key="frame" x="0.0" y="196" width="375" height="78"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SSA-jP-SZZ" id="ozb-k0-e3J">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="77.5"/>
@@ -149,6 +186,8 @@
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
                     <connections>
                         <outlet property="newTitleTextField" destination="6fh-Sl-k3T" id="A7J-Gv-0m6"/>
+                        <outlet property="offsetBetweenTitlesValueLabel" destination="hQV-vD-bPB" id="YyW-DF-c3F"/>
+                        <outlet property="offsetBewteenTitlesStepper" destination="8ej-WI-ewh" id="3xN-kl-97F"/>
                         <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
                         <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
                         <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -140,6 +140,39 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="78" id="SSA-jP-SZZ">
+                                        <rect key="frame" x="0.0" y="164" width="375" height="78"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SSA-jP-SZZ" id="ozb-k0-e3J">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="77.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Additional Titles" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LM7-gf-Qer">
+                                                    <rect key="frame" x="8" y="8" width="157.5" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6fh-Sl-k3T">
+                                                    <rect key="frame" x="8" y="37" width="359" height="32.5"/>
+                                                    <nil key="textColor"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                    <connections>
+                                                        <outlet property="delegate" destination="DNs-Uf-ScM" id="gez-QF-PPT"/>
+                                                    </connections>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="LM7-gf-Qer" firstAttribute="top" secondItem="ozb-k0-e3J" secondAttribute="topMargin" id="3Sr-fF-Evb"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="6fh-Sl-k3T" secondAttribute="trailing" id="GCV-XB-QfX"/>
+                                                <constraint firstItem="LM7-gf-Qer" firstAttribute="leading" secondItem="ozb-k0-e3J" secondAttribute="leadingMargin" id="J4y-QL-2Lx"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="6fh-Sl-k3T" secondAttribute="bottom" id="PDn-CV-RNI"/>
+                                                <constraint firstItem="6fh-Sl-k3T" firstAttribute="top" secondItem="LM7-gf-Qer" secondAttribute="bottom" constant="8" symbolic="YES" id="dOi-eH-H7g"/>
+                                                <constraint firstItem="6fh-Sl-k3T" firstAttribute="leading" secondItem="LM7-gf-Qer" secondAttribute="leading" id="q5X-X8-Lse"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -151,6 +184,7 @@
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
                     <connections>
                         <outlet property="labelsOnEndsFloatToEdgesSwitch" destination="1rn-n8-Gim" id="1ca-ga-wCZ"/>
+                        <outlet property="newTitleTextField" destination="6fh-Sl-k3T" id="A7J-Gv-0m6"/>
                         <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
                         <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
                         <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,30 +30,105 @@
         <scene sceneID="gTT-st-N6h">
             <objects>
                 <tableViewController id="DNs-Uf-ScM" customClass="TableViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
+                        <sections>
+                            <tableViewSection id="7eX-e6-5TY">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
+                                                    <rect key="frame" x="8" y="8" width="214" height="27.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
+                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="S4w-Ka-Spx"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="centerY" secondItem="Cj7-PA-8So" secondAttribute="centerY" id="BBJ-wl-qhB"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Cj7-PA-8So" secondAttribute="bottom" id="Csm-ti-vnT"/>
+                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="top" secondItem="eu6-QD-iyM" secondAttribute="topMargin" id="OqY-z3-Hx4"/>
+                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="leading" secondItem="eu6-QD-iyM" secondAttribute="leadingMargin" id="er7-0P-cZw"/>
+                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="trailing" secondItem="eu6-QD-iyM" secondAttribute="trailingMargin" id="ymo-NR-6Sr"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="76" id="fgH-fF-iXU">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fgH-fF-iXU" id="KzF-qm-fWO">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorOffsetFromLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gBj-lX-mgM">
+                                                    <rect key="frame" x="8" y="8" width="190" height="22"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hRx-s7-rUd">
+                                                    <rect key="frame" x="318" y="3.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleSelectorOffsetFromLabelSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Wxk-da-eZz"/>
+                                                    </connections>
+                                                </switch>
+                                                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="5TY-It-D6n">
+                                                    <rect key="frame" x="8" y="38.5" width="94" height="29"/>
+                                                    <connections>
+                                                        <action selector="didChageSelectorOffsetFromlabelStepper:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Oxd-13-M0V"/>
+                                                    </connections>
+                                                </stepper>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzl-12-ShV">
+                                                    <rect key="frame" x="110" y="43" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="5TY-It-D6n" firstAttribute="leading" secondItem="KzF-qm-fWO" secondAttribute="leadingMargin" id="4gH-mL-cFy"/>
+                                                <constraint firstItem="5TY-It-D6n" firstAttribute="top" secondItem="gBj-lX-mgM" secondAttribute="bottom" constant="8.5" id="5PN-eW-jMM"/>
+                                                <constraint firstItem="Mzl-12-ShV" firstAttribute="centerY" secondItem="5TY-It-D6n" secondAttribute="centerY" id="8f7-Wh-44T"/>
+                                                <constraint firstItem="Mzl-12-ShV" firstAttribute="leading" secondItem="5TY-It-D6n" secondAttribute="trailing" constant="8" id="IG2-oB-3dL"/>
+                                                <constraint firstItem="gBj-lX-mgM" firstAttribute="top" secondItem="KzF-qm-fWO" secondAttribute="topMargin" id="NwL-aR-vSm"/>
+                                                <constraint firstItem="hRx-s7-rUd" firstAttribute="trailing" secondItem="KzF-qm-fWO" secondAttribute="trailingMargin" id="PHc-oU-Feh"/>
+                                                <constraint firstItem="hRx-s7-rUd" firstAttribute="centerY" secondItem="gBj-lX-mgM" secondAttribute="centerY" id="ZbQ-ax-1CN"/>
+                                                <constraint firstItem="gBj-lX-mgM" firstAttribute="leading" secondItem="KzF-qm-fWO" secondAttribute="leadingMargin" id="rUB-C1-mHG"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="5TY-It-D6n" secondAttribute="bottom" id="wGq-09-jGv"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
                         <connections>
                             <outlet property="dataSource" destination="DNs-Uf-ScM" id="47K-WW-Nub"/>
                             <outlet property="delegate" destination="DNs-Uf-ScM" id="x3p-NO-uE0"/>
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
+                    <connections>
+                        <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
+                        <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
+                        <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Cig-mt-BGt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="350" y="773"/>
+            <point key="canvasLocation" x="349.60000000000002" y="772.26386806596713"/>
         </scene>
     </scenes>
 </document>

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -338,10 +338,6 @@ public class YSSegmentedControl: UIView {
                                                                 constant: 0))
                 }
                 
-                var viewState = item.viewState
-                viewState.horizontalTrailingOffset = self.viewState.offsetBetweenTitles
-                item.viewState = viewState
-                
                 if index == items.count - 1 {
                     scrollView.addConstraint(NSLayoutConstraint(item: item,
                                                                  attribute: .trailing,
@@ -350,11 +346,6 @@ public class YSSegmentedControl: UIView {
                                                                  attribute: .trailing,
                                                                  multiplier: 1.0,
                                                                  constant: 0.0))
-                    
-                    var viewState = item.viewState
-                    viewState.horizontalTrailingOffset = 0
-                    item.viewState = viewState
-                    
                 }
                 
                 // Vertical constraints
@@ -378,6 +369,14 @@ public class YSSegmentedControl: UIView {
         for (index, item) in items.enumerated() {
             var viewState = item.viewState
             viewState.title = self.viewState.titles[index]
+            
+            if index == items.count - 1 {
+                viewState.horizontalTrailingOffset = 0
+            }
+            else {
+                viewState.horizontalTrailingOffset = self.viewState.offsetBetweenTitles
+            }
+            
             item.viewState = viewState
         }
         

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -34,11 +34,13 @@ public struct YSSegmentedControlAppearance {
     
     /**
      Whether or not the selector spans the full width of the
-     YSSegmentedControlItem.
-     If set to true, the selector will span the entire width of the item;
-     if set to false, the selector will span the entire width of the label.
+     YSSegmentedControlItem's label.
+     If set to true, the selector will span the full width of the label;
+     if set to false, the selector will span the entire width of the item.
+     
+     Defaults to false.
      */
-    public var selectorSpansFullItemWidth: Bool
+    public var selectorSpansLabelWidth: Bool
 }
 
 // MARK: - Control Item
@@ -275,7 +277,7 @@ public class YSSegmentedControl: UIView {
             selectorHeight: 2,
             labelTopPadding: 0,
             selectorOffsetFromLabel: nil,
-            selectorSpansFullItemWidth: true)
+            selectorSpansLabelWidth: false)
     }
     
     // MARK: Select
@@ -317,11 +319,11 @@ public class YSSegmentedControl: UIView {
         
         let horizontalConstrainingView: UIView
         
-        if appearance.selectorSpansFullItemWidth {
-            horizontalConstrainingView = item
+        if appearance.selectorSpansLabelWidth {
+            horizontalConstrainingView = item.label
         }
         else {
-            horizontalConstrainingView = item.label
+            horizontalConstrainingView = item
         }
         
         selectorLeadingConstraint = NSLayoutConstraint(item: selector,

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -31,26 +31,6 @@ public struct YSSegmentedControlAppearance {
      otherwise the selector will be this distance from the bottom of the label.
      */
     public var selectorOffsetFromLabel: CGFloat?
-    
-    /**
-     Whether or not the selector spans the full width of the
-     YSSegmentedControlItem's label.
-     If set to true, the selector will span the full width of the label;
-     if set to false, the selector will span the entire width of the item.
-     
-     Defaults to false.
-     */
-    public var selectorSpansLabelWidth: Bool
-    
-    /**
-     Whether or not the labels on the ends (first and last) float to the edges
-     or are centered within the item.
-     If set to `true`, then the labels float to the edges;
-     if set to `false`, then the labels are centered.
-     
-     Default value is `false`.
-     */
-    public var labelsOnEndsFloatToEdges: Bool
 }
 
 // MARK: - Control Item
@@ -231,21 +211,7 @@ public class YSSegmentedControl: UIView {
         reset()
         backgroundColor = appearance.backgroundColor
         for (index, title) in titles.enumerated() {
-            let labelAlignment: NSTextAlignment
-            
-            if appearance.labelsOnEndsFloatToEdges {
-                switch index {
-                case 0:
-                    labelAlignment = .left
-                case titles.count - 1:
-                    labelAlignment = .right
-                default:
-                    labelAlignment = .center
-                }
-            }
-            else {
-                labelAlignment = .center
-            }
+            let labelAlignment: NSTextAlignment = .center
             
             let item = YSSegmentedControlItem(
                 frame: .zero,
@@ -329,9 +295,7 @@ public class YSSegmentedControl: UIView {
             bottomLineHeight: 0.5,
             selectorHeight: 2,
             itemTopPadding: 0,
-            selectorOffsetFromLabel: nil,
-            selectorSpansLabelWidth: false,
-            labelsOnEndsFloatToEdges: false)
+            selectorOffsetFromLabel: nil)
     }
     
     // MARK: Select
@@ -369,14 +333,7 @@ public class YSSegmentedControl: UIView {
         
         let item = items[selectedIndex]
         
-        let horizontalConstrainingView: UIView
-        
-        if appearance.selectorSpansLabelWidth {
-            horizontalConstrainingView = item.label
-        }
-        else {
-            horizontalConstrainingView = item
-        }
+        let horizontalConstrainingView = item.label
         
         selectorLeadingConstraint = NSLayoutConstraint(item: selector,
                                                        attribute: .leading,

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -206,7 +206,8 @@ public class YSSegmentedControl: UIView {
     private var selector = UIView()
     private var selectorHeightConstraint: NSLayoutConstraint?
 
-    private var bottomLine = CALayer()
+    private var bottomLine = UIView()
+    private var bottomLineHeightConstraint: NSLayoutConstraint?
     
     fileprivate var selectorLeadingConstraint: NSLayoutConstraint?
     fileprivate var selectorWidthConstraint: NSLayoutConstraint?
@@ -223,7 +224,25 @@ public class YSSegmentedControl: UIView {
         }
         
         // bottomLine
-        layer.addSublayer(bottomLine)
+        addSubview(bottomLine)
+        bottomLine.translatesAutoresizingMaskIntoConstraints = false
+        let views = ["bottomLine": bottomLine]
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[bottomLine]|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: views))
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[bottomLine]|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: views))
+        bottomLineHeightConstraint = NSLayoutConstraint(item: bottomLine,
+                                                        attribute: .height,
+                                                        relatedBy: .equal,
+                                                        toItem: nil,
+                                                        attribute: .notAnAttribute,
+                                                        multiplier: 1.0,
+                                                        constant: viewState?.bottomLineHeight ?? 0)
+        addConstraint(bottomLineHeightConstraint!)
         
         // selector
         addSubview(selector)
@@ -325,7 +344,8 @@ public class YSSegmentedControl: UIView {
         backgroundColor = viewState.backgroundColor
         
         // bottom line
-        bottomLine.backgroundColor = viewState.bottomLineColor.cgColor
+        bottomLineHeightConstraint?.constant = viewState.bottomLineHeight
+        bottomLine.backgroundColor = viewState.bottomLineColor
         
         // selector
         selectorHeightConstraint?.constant = viewState.selectorHeight
@@ -333,16 +353,6 @@ public class YSSegmentedControl: UIView {
         selectItem(at: selectedIndex, withAnimation: true)
         
         setNeedsLayout()
-    }
-    
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        bottomLine.frame = CGRect(
-            x: 0,
-            y: frame.size.height - viewState.bottomLineHeight,
-            width: frame.size.width,
-            height: viewState.bottomLineHeight)
     }
     
     // MARK: Select

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -201,12 +201,12 @@ public class YSSegmentedControl: UIView {
         }
     }
     
-    var items = [YSSegmentedControlItem]()
+    private var items = [YSSegmentedControlItem]()
     
-    var selector = UIView()
+    private var selector = UIView()
     private var selectorHeightConstraint: NSLayoutConstraint?
 
-    var bottomLine = CALayer()
+    private var bottomLine = CALayer()
     
     fileprivate var selectorLeadingConstraint: NSLayoutConstraint?
     fileprivate var selectorWidthConstraint: NSLayoutConstraint?

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -18,8 +18,8 @@ public struct YSSegmentedControlViewState {
     public var selectedTextAttributes: [String : Any]
     
     public var bottomLineColor: UIColor
-    public var selectorColor: UIColor
     public var bottomLineHeight: CGFloat
+    public var selectorColor: UIColor
     public var selectorHeight: CGFloat
     public var itemTopPadding: CGFloat
     
@@ -49,8 +49,8 @@ public struct YSSegmentedControlViewState {
         unselectedTextAttributes = [:]
         selectedTextAttributes = [:]
         bottomLineColor = .black
-        selectorColor = .black
         bottomLineHeight = 0.5
+        selectorColor = .black
         selectorHeight = 2
         itemTopPadding = 0
         selectorOffsetFromLabel = nil

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -247,6 +247,7 @@ public class YSSegmentedControl: UIView {
         addConstraint(bottomLineHeightConstraint!)
         
         // scrollView
+        scrollView.showsHorizontalScrollIndicator = false
         addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         views = ["scrollView": scrollView]

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -31,6 +31,12 @@ public struct YSSegmentedControlAppearance {
      otherwise the selector will be this distance from the bottom of the label.
      */
     public var selectorOffsetFromLabel: CGFloat?
+    
+    /**
+     The horizontal distance between the trailing edge of each title
+     and its subsequent title's leading edge.
+     */
+    public var offsetBetweenTitles: CGFloat
 }
 
 // MARK: - Control Item
@@ -251,6 +257,7 @@ public class YSSegmentedControl: UIView {
 
             var viewState = item.viewState
             viewState.title = title
+            viewState.horizontalTrailingOffset = appearance.offsetBetweenTitles
             item.viewState = viewState
 
             addSubview(item)
@@ -312,7 +319,8 @@ public class YSSegmentedControl: UIView {
             bottomLineHeight: 0.5,
             selectorHeight: 2,
             itemTopPadding: 0,
-            selectorOffsetFromLabel: nil)
+            selectorOffsetFromLabel: nil,
+            offsetBetweenTitles: 48)
     }
     
     // MARK: Select

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -159,7 +159,7 @@ class YSSegmentedControlItem: UIControl {
     
     private func update() {
         label.attributedText = NSAttributedString(string: viewState.title, attributes: viewState.titleAttributes)
-        labelTrailingConstraint?.constant = viewState.horizontalTrailingOffset
+        labelTrailingConstraint?.constant = -viewState.horizontalTrailingOffset
         
         backgroundColor = viewState.backgroundColor
         

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -81,7 +81,6 @@ class YSSegmentedControlItem: UIControl {
     // MARK: Init
     
     init(frame: CGRect,
-         appearance: YSSegmentedControlAppearance,
          willPress: YSSegmentedControlItemAction?,
          didPress: YSSegmentedControlItemAction?,
          labelAlignment: NSTextAlignment) {
@@ -234,7 +233,6 @@ public class YSSegmentedControl: UIView {
             
             let item = YSSegmentedControlItem(
                 frame: .zero,
-                appearance: appearance,
                 willPress: { [weak self] segmentedControlItem in
                     guard let weakSelf = self else {
                         return

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -44,7 +44,7 @@ class YSSegmentedControlItem: UIControl {
     private var willPress: YSSegmentedControlItemAction?
     private var didPress: YSSegmentedControlItemAction?
     
-    var label: UILabel!
+    let label = UILabel()
     let labelAlignment: NSTextAlignment
     
     // MARK: Init
@@ -74,7 +74,6 @@ class YSSegmentedControlItem: UIControl {
     }
     
     private func commonInit() {
-        label = UILabel()
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -189,7 +189,7 @@ public typealias YSSegmentedControlAction = (_ segmentedControl: YSSegmentedCont
 
 public class YSSegmentedControl: UIView {
     
-    // MARK: Properties
+    // MARK:- Properties
     
     weak var delegate: YSSegmentedControlDelegate?
     public var action: YSSegmentedControlAction?
@@ -210,7 +210,7 @@ public class YSSegmentedControl: UIView {
     fileprivate var selectorWidthConstraint: NSLayoutConstraint?
     fileprivate var selectorBottomConstraint: NSLayoutConstraint?
     
-    // MARK: Init
+    // MARK:- Init
     
     public init (frame: CGRect, viewState: YSSegmentedControlViewState? = nil, action: YSSegmentedControlAction? = nil) {
         super.init (frame: frame)

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -396,7 +396,8 @@ public class YSSegmentedControl: UIView {
         // selector
         selectorHeightConstraint?.constant = viewState.selectorHeight
         selector.backgroundColor = viewState.selectorColor
-        selectItem(at: selectedIndex, withAnimation: true)
+        
+        selectItem(at: selectedIndex, withAnimation: false)
         
         setNeedsLayout()
     }

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -407,6 +407,19 @@ public class YSSegmentedControl: UIView {
     public func selectItem(at index: Int, withAnimation animation: Bool) {
         self.selectedIndex = index
         moveSelector(at: index, withAnimation: animation)
+        
+        assert(index < items.count, "index was out of bounds of items")
+        
+        // scroll to the selected item if its bounds are out of the scrollview
+        let selectedItemFrame = items[index].frame
+        let scrollViewContentOffsetRightPoint = scrollView.contentOffset.x + scrollView.bounds.size.width
+        let selectedItemFrameRightPoint = selectedItemFrame.origin.x + selectedItemFrame.size.width
+        
+        if selectedItemFrame.origin.x < scrollView.contentOffset.x ||
+            scrollViewContentOffsetRightPoint < selectedItemFrameRightPoint {
+            scrollView.scrollRectToVisible(selectedItemFrame, animated: animation)
+        }
+        
         for item in items {
             if item == items[index] {
                 var viewState = item.viewState

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -361,6 +361,12 @@ public class YSSegmentedControl: UIView {
                                                             multiplier: 1.0,
                                                             constant: 0.0))
             }
+            
+            // If titles have been removed such the selectedIndex is out of
+            // bounds, bump it back by 1.
+            if selectedIndex >= viewState.titles.count {
+                selectedIndex = viewState.titles.count > 0 ? viewState.titles.count - 1 : 0
+            }
         }
         
         // Update the states of all the items

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -210,7 +210,7 @@ public class YSSegmentedControl: UIView {
     private func draw() {
         reset()
         backgroundColor = appearance.backgroundColor
-        for (index, title) in titles.enumerated() {
+        for title in titles {
             let labelAlignment: NSTextAlignment = .center
             
             let item = YSSegmentedControlItem(

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -212,10 +212,13 @@ public class YSSegmentedControl: UIView {
     
     // MARK: Init
     
-    public init (frame: CGRect, titles: [String], action: YSSegmentedControlAction? = nil) {
+    public init (frame: CGRect, viewState: YSSegmentedControlViewState? = nil, action: YSSegmentedControlAction? = nil) {
         super.init (frame: frame)
         self.action = action
-        self.viewState.titles = titles // TODO: Fix this. Make this initializer take a view state
+        
+        if let viewState = viewState {
+            self.viewState = viewState
+        }
     }
     
     required public init? (coder aDecoder: NSCoder) {


### PR DESCRIPTION
This PR converts the `YSSegmentedControl` and `YSSegmentedControlItem` to use ViewStates, and also makes the titles on the segmented control scrollable if they exceed the bounds of the segmented control.

# ViewStates

Both `YSSegmentedControl` and `YSSegmentedControlItem` now use view states exclusively to manage their view state. To change any view state property, simply make a copy of the view state, change any properties, and then re-assign it:

```swift
var viewState = item.viewState
item.title = "Active"
item.vieState = viewState
```

`YSSegmentedControl`'s view state includes the array of titles, as well as all of the former properties that were housed inside `YSSegmentedControlAppearance`.

# Scrollability

This pull request also adds a `UIScrollView` to `YSSegmentedControl`, and adds all of the items to that scroll view, so that if the items exceed the horizontal bounds of the segmented control, then they scroll. With this changes comes converting everything in this library to use AutoLayout, and not frames directly.

Additionally, `YSSegmentedControl` now left aligns its titles. Center alignment may come in a future pull request, however, it is not needed as of now.