### PR TITLE
Add option to center items horizontally

### DIFF
--- a/YSSegmentedControl.podspec
+++ b/YSSegmentedControl.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "YSSegmentedControl"
-  s.version      = "0.3.1"
+  s.version      = "0.4.0"
   s.summary      = "Android style segmented control written in swift. Fully customisable."
 
   # This description is used to generate tags and improve search results.

--- a/YSSegmentedControl.xcodeproj/project.pbxproj
+++ b/YSSegmentedControl.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03F2EC9B1F4F435F000AD869 /* UIView+AutoLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC9A1F4F435F000AD869 /* UIView+AutoLayout.swift */; };
 		B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA61BF24CB30064F127 /* TableViewController.swift */; };
 		B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA81BF24CB30064F127 /* AppDelegate.swift */; };
 		B28BBFB31BF24CB30064F127 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B28BBFA91BF24CB30064F127 /* LaunchScreen.xib */; };
@@ -27,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03F2EC9A1F4F435F000AD869 /* UIView+AutoLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+AutoLayout.swift"; sourceTree = "<group>"; };
 		B28BBFA61BF24CB30064F127 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		B28BBFA81BF24CB30064F127 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B28BBFAA1BF24CB30064F127 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
@@ -82,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				B28BBFB01BF24CB30064F127 /* YSSegmentedControl.swift */,
+				03F2EC9A1F4F435F000AD869 /* UIView+AutoLayout.swift */,
 			);
 			path = YSSegmentedControl;
 			sourceTree = "<group>";
@@ -234,6 +237,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */,
+				03F2EC9B1F4F435F000AD869 /* UIView+AutoLayout.swift in Sources */,
 				B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */,
 				B28BBFB71BF24CB30064F127 /* YSSegmentedControl.swift in Sources */,
 			);

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -24,6 +24,8 @@ class TableViewController: UITableViewController {
     @IBOutlet weak var bottomLineHeightStepper: UIStepper!
     @IBOutlet weak var bottomLineHeightValueLabel: UILabel!
     
+    @IBOutlet weak var shouldEvenlySpaceItemsHorizontallySwitch: UISwitch!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero)
@@ -93,6 +95,12 @@ class TableViewController: UITableViewController {
         segmented.viewState = viewState
     }
     
+    @IBAction func didToggleShouldEvenlySpaceItemsHorizontallySwitch(_ sender: UISwitch) {
+        var viewState = segmented.viewState
+        viewState.shouldEvenlySpaceItemsHorizontally = sender.isOn
+        segmented.viewState = viewState
+    }
+    
     // MARK: Helpers
     
     func updateAppearanceConfigurationUI() {
@@ -108,6 +116,7 @@ class TableViewController: UITableViewController {
         bottomLineHeightStepper.value = Double(segmented.viewState.bottomLineHeight)
         bottomLineHeightValueLabel.text = "\(bottomLineHeightStepper.value)"
         
+        shouldEvenlySpaceItemsHorizontallySwitch.isOn = segmented.viewState.shouldEvenlySpaceItemsHorizontally
     }
 }
 

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -58,6 +58,7 @@ class TableViewController: UITableViewController {
     
     @IBAction func didTapResetButton(_ sender: UIButton) {
         segmented.viewState = YSSegmentedControlViewState()
+        updateAppearanceConfigurationUI()
     }
     
     @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Wwv-lb-7V5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Wwv-lb-7V5">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -212,6 +212,35 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="cW8-m5-T92">
+                                        <rect key="frame" x="0.0" y="350" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cW8-m5-T92" id="IOp-cM-xNS">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="shouldEvenlySpaceItemsHorizontally" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ayd-t9-qaS">
+                                                    <rect key="frame" x="8" y="8" width="283" height="27.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Rdw-kH-LFh">
+                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleShouldEvenlySpaceItemsHorizontallySwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Av2-hf-3wr"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Ayd-t9-qaS" firstAttribute="top" secondItem="IOp-cM-xNS" secondAttribute="topMargin" id="8pB-CE-N51"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Ayd-t9-qaS" secondAttribute="bottom" id="KG6-Fc-8va"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Rdw-kH-LFh" secondAttribute="trailing" id="QOa-L9-6fH"/>
+                                                <constraint firstItem="Rdw-kH-LFh" firstAttribute="centerY" secondItem="Ayd-t9-qaS" secondAttribute="centerY" id="bvk-sl-S0g"/>
+                                                <constraint firstItem="Ayd-t9-qaS" firstAttribute="leading" secondItem="IOp-cM-xNS" secondAttribute="leadingMargin" id="j6S-7p-xTw"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -230,6 +259,7 @@
                         <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
                         <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
                         <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>
+                        <outlet property="shouldEvenlySpaceItemsHorizontallySwitch" destination="Rdw-kH-LFh" id="mnJ-g9-v3k"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Cig-mt-BGt" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/YSSegmentedControl/YSSegmentedControl/UIView+AutoLayout.swift
+++ b/YSSegmentedControl/YSSegmentedControl/UIView+AutoLayout.swift
@@ -1,0 +1,186 @@
+//
+//  UIView+AutoLayout.swift
+//  YSSegmentedControl
+//
+//  Created by Josh Sklar on 2/1/17.
+//  Copyright © 2017 StockX. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    
+    // MARK: Edges
+    
+    /**
+     Makes the edges of the receiver equal to the edges of `view`.
+     
+     Note: `view` must already be constrained, and both the receiver
+     and `view` must have a common superview.
+     */
+    func makeEdgesEqualTo(_ view: UIView) {
+        makeAttribute(.leading, equalToOtherView: view, attribute: .leading)
+        makeAttribute(.trailing, equalToOtherView: view, attribute: .trailing)
+        makeAttribute(.top, equalToOtherView: view, attribute: .top)
+        makeAttribute(.bottom, equalToOtherView: view, attribute: .bottom)
+    }
+    
+    /**
+     Makes the edges of the receiver equal to its superview with an otion to
+     specify an inset value.
+     
+     If the receiver does not have a superview, this does nothing.
+     */
+    func makeEdgesEqualToSuperview(inset: CGFloat = 0) {
+        makeAttributesEqualToSuperview([.leading, .top], offset: inset)
+        makeAttributesEqualToSuperview([.trailing, .bottom], offset: -inset)
+    }
+    
+    // MARK: Attributes
+    
+    /**
+     Creates and applies a constraint with the given attribute equal to that
+     same attribute of the superview, and returns the constraint.
+     */
+    func makeConstraintEqualToSuperview(_ attribute: NSLayoutAttribute) -> NSLayoutConstraint? {
+        guard let superview = superview else {
+            return nil
+        }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let constraint = NSLayoutConstraint(item: self,
+                                            attribute: attribute,
+                                            relatedBy: .equal,
+                                            toItem: superview,
+                                            attribute: attribute,
+                                            multiplier: 1.0,
+                                            constant: 0.0)
+        superview.addConstraint(constraint)
+        return constraint
+    }
+    /**
+     Applies constraints to the receiver with attributes `attributes` all
+     equal to its superview.
+     */
+    func makeAttributesEqualToSuperview(_ attributes: [NSLayoutAttribute], offset: CGFloat = 0) {
+        makeAttributes(attributes, relationToSuperview: .equal, offset: offset)
+    }
+    
+    func makeAttributesGreaterThanOrEqualToSuperview(_ attributes: [NSLayoutAttribute], offset: CGFloat = 0) {
+        makeAttributes(attributes, relationToSuperview: .greaterThanOrEqual, offset: offset)
+    }
+    
+    func makeAttributesLessThanOrEqualToSuperview(_ attributes: [NSLayoutAttribute], offset: CGFloat = 0) {
+        makeAttributes(attributes, relationToSuperview: .lessThanOrEqual, offset: offset)
+    }
+    
+    func makeAttributes(_ attributes: [NSLayoutAttribute], relationToSuperview relation: NSLayoutRelation = .equal, offset: CGFloat = 0) {
+        guard let superview = superview else {
+            return
+        }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        attributes.forEach {
+            superview.addConstraint(NSLayoutConstraint(item: self,
+                                                       attribute: $0,
+                                                       relatedBy: relation,
+                                                       toItem: superview,
+                                                       attribute: $0,
+                                                       multiplier: 1.0,
+                                                       constant: offset))
+        }
+    }
+    
+    /**
+     Creates and applies a constraint to the receiver with attribute
+     `attribute` and the specified constant, and returns the constraint.
+     */
+    func makeConstraint(for attribute: NSLayoutAttribute, equalTo constant: CGFloat) -> NSLayoutConstraint? {
+        guard let superview = superview else {
+            return nil
+        }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let constraint = NSLayoutConstraint(item: self,
+                                            attribute: attribute,
+                                            relatedBy: .equal,
+                                            toItem: nil,
+                                            attribute: .notAnAttribute,
+                                            multiplier: 1.0,
+                                            constant: constant)
+        superview.addConstraint(constraint)
+        return constraint
+    }
+    
+    /**
+     Applies a constraint to the receiver with attribute `attribute` and
+     the specified constant.
+     */
+    func makeAttribute(_ attribute: NSLayoutAttribute, equalTo constant: CGFloat) {
+        guard let superview = superview else {
+            return
+        }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let constraint = NSLayoutConstraint(item: self,
+                                            attribute: attribute,
+                                            relatedBy: .equal,
+                                            toItem: nil,
+                                            attribute: .notAnAttribute,
+                                            multiplier: 1.0,
+                                            constant: constant)
+        superview.addConstraint(constraint)
+    }
+    
+    /**
+     Applies a constraint with the attribute `attribute` from the receiver to
+     the view `otherView` with attribute `attribute`.
+     */
+    func makeAttribute(_ attribute: NSLayoutAttribute,
+                       equalToOtherView otherView: UIView,
+                       attribute otherAttribute: NSLayoutAttribute,
+                       constant: CGFloat = 0) {
+        guard let sv = otherView.superview,
+            sv == self.superview else {
+                return
+        }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let attribute = NSLayoutConstraint(item: self,
+                                           attribute: attribute,
+                                           relatedBy: .equal,
+                                           toItem: otherView,
+                                           attribute: otherAttribute,
+                                           multiplier: 1.0,
+                                           constant: constant)
+        sv.addConstraint(attribute)
+    }
+    
+    
+    // MARK: Utility
+    
+    /**
+     Removes all the constrains where the receiver is either the
+     firstItem or secondItem.
+     
+     If the receiver does not have a superview, this only removes the
+     constraints that the receiver owns.
+     */
+    func removeAllConstraints() {
+        guard let superview = superview else {
+            removeConstraints(constraints)
+            return
+        }
+        
+        for constraint in superview.constraints where (constraint.firstItem as? UIView == self || constraint.secondItem as? UIView == self) {
+            superview.removeConstraint(constraint)
+        }
+        
+        removeConstraints(constraints)
+    }
+}

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -452,8 +452,12 @@ public class YSSegmentedControl: UIView {
             var viewState = item.viewState
             viewState.title = self.viewState.titles[index]
             
-            // Don't add horizontal trailing offset to the last one,
-            // otherwise there is unecessary scrolling.
+            /**
+             If shouldEvenlySpaceItemsHorizontally is set to true, don't add
+             any trailing offset, as we want the items to be evenly spaced.
+             Or, if that is set ot false, then don't add horizontal trailing
+             offset to the last one, otherwise there is potentially unecessary scrolling.
+             */
             if self.viewState.shouldEvenlySpaceItemsHorizontally ||
                 index == items.count - 1 {
                 viewState.horizontalTrailingOffset = 0

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -39,6 +39,23 @@ public struct YSSegmentedControlViewState {
     public var offsetBetweenTitles: CGFloat
     
     /**
+     Whether or not the items should be evenly spaced horizontally,
+     or laid out sequentially, one directly after the other.
+     
+     If this is set to true, then the first item will be constrained
+     to the leading edge of the superview, and the last label will be
+     constrained to the trailing edge of the superview, and all labels in
+     between will be evenly spaced.
+     
+     If this is set to false, then the labels are laid out sequentially,
+     one directly after the other, and they scroll if they extend off the edge
+     of the superview.
+     
+     Defaults to false.
+     */
+    public var shouldEvenlySpaceItemsHorizontally: Bool
+    
+    /**
      The titles that show inside the segmented control.
      */
     public var titles: [String]
@@ -55,6 +72,7 @@ public struct YSSegmentedControlViewState {
         itemTopPadding = 0
         selectorOffsetFromLabel = nil
         offsetBetweenTitles = 48
+        shouldEvenlySpaceItemsHorizontally = false
         titles = []
     }
 }

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -359,7 +359,8 @@ public class YSSegmentedControl: UIView {
     
     private func update(_ oldViewState: YSSegmentedControlViewState) {
         // If the number of titles have changed, re-add all of the items.
-        if oldViewState.titles.count != viewState.titles.count {
+        if oldViewState.titles.count != viewState.titles.count ||
+            oldViewState.shouldEvenlySpaceItemsHorizontally != viewState.shouldEvenlySpaceItemsHorizontally {
             // Remove all items
             items.forEach { $0.removeFromSuperview() }
             items.removeAll()

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -336,34 +336,16 @@ public class YSSegmentedControl: UIView {
             
             // First
             if index == 0 {
-                scrollView.addConstraint(NSLayoutConstraint(item: item,
-                                                            attribute: .leading,
-                                                            relatedBy: .equal,
-                                                            toItem: scrollView,
-                                                            attribute: .leading,
-                                                            multiplier: 1.0,
-                                                            constant: 0.0))
+                item.makeAttributesEqualToSuperview([.leading])
             }
             // Middle or last
             else {
                 let previousItem = items[index - 1]
-                scrollView.addConstraint(NSLayoutConstraint(item: item,
-                                                            attribute: .leading,
-                                                            relatedBy: .equal,
-                                                            toItem: previousItem,
-                                                            attribute: .trailing,
-                                                            multiplier: 1.0,
-                                                            constant: 0))
+                item.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
             }
             // Last
             if index == items.count - 1 {
-                scrollView.addConstraint(NSLayoutConstraint(item: item,
-                                                            attribute: .trailing,
-                                                            relatedBy: .equal,
-                                                            toItem: scrollView,
-                                                            attribute: .trailing,
-                                                            multiplier: 1.0,
-                                                            constant: 0.0))
+                item.makeAttributesEqualToSuperview([.trailing])
             }
             
             // Vertical constraints
@@ -371,13 +353,7 @@ public class YSSegmentedControl: UIView {
             let views = ["item": item]
             scrollView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[item]|", options: [], metrics: nil, views: views))
             // Need to add this height constraint because the scrollView won't stretch the label to the bottom
-            scrollView.addConstraint(NSLayoutConstraint(item: item,
-                                                        attribute: .height,
-                                                        relatedBy: .equal,
-                                                        toItem: scrollView,
-                                                        attribute: .height,
-                                                        multiplier: 1.0,
-                                                        constant: 0.0))
+            item.makeAttributesEqualToSuperview([.height])
         }
     }
     

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -313,6 +313,18 @@ public class YSSegmentedControl: UIView {
     // MARK:- ViewState
     
     /**
+     Removes all the items and their associated views (such as spacer views
+     and other constraining views) from the scrollView.
+     */
+    private func removeItemsAndAssociatedViews() {
+        items.forEach { $0.removeFromSuperview() }
+        items.removeAll()
+        spacerViews.forEach { $0.removeFromSuperview() }
+        spacerViews.removeAll()
+        horizontalScrollViewConstrainingView.removeFromSuperview()
+    }
+    
+    /**
      Lays out all of the YSSegmentedControlItems by adding them to the subview,
      and then constrainign them properly based on the state).
      */
@@ -423,12 +435,7 @@ public class YSSegmentedControl: UIView {
             oldViewState.shouldEvenlySpaceItemsHorizontally != viewState.shouldEvenlySpaceItemsHorizontally {
             
             // Remove all items
-            items.forEach { $0.removeFromSuperview() }
-            items.removeAll()
-            spacerViews.forEach { $0.removeFromSuperview() }
-            spacerViews.removeAll()
-            horizontalScrollViewConstrainingView.removeFromSuperview()
-            
+            removeItemsAndAssociatedViews()
             layoutItems()
             
             // If titles have been removed such the selectedIndex is out of


### PR DESCRIPTION
This pull request adds in the option to evenly space the items horizontally, with the first one anchored to the leading edge, and the last one anchored to the trailing edge of the `YSSegmentedControl`.

# `YSSegmentedControlAppearance` Enhancements

### 1. `shouldEvenlySpaceItemsHorizontally: Bool`

*Default value: `false`*

This new property allows for evenly spacing the items horizontally along the scrollView, as opposed to having them positioned sequentially left-to-right. When this is set to `true`, the left-most item is anchored to the left edge of the `YSSegmentedControl`, the right-most item is anchored to the right edge of the `YSSegmentedControl`, and all the inner items are spaced out evenly using spacer views.

# Demo Enhancements

This enhances the demo view controller by adding an interface to configure the segmented control's `shouldEvenlySpaceItemsHorizontally`.

## Screenshots
![screen shot 2017-08-29 at 12 18 55 pm](https://user-images.githubusercontent.com/879038/29831797-3ceba332-8cb4-11e7-8843-6505618ce159.png)

