### PR TITLE
Allow for backwards compatibility for item width and spacing

### DIFF
--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -340,7 +340,7 @@ public class YSSegmentedControl: UIView {
         // Re-Add all items
         for _ in viewState.titles {
             let item = YSSegmentedControlItem(
-                frame: CGRect(x: 0, y: 0, width: 100, height: 44),
+                frame: .zero,
                 willPress: { [weak self] segmentedControlItem in
                     guard let weakSelf = self else {
                         return

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -363,7 +363,7 @@ public class YSSegmentedControl: UIView {
             scrollView.addSubview(item)
             items.append(item)
         }
-        
+
         if viewState.shouldEvenlySpaceItemsHorizontally {
             scrollView.addSubview(horizontalScrollViewConstrainingView)
             
@@ -380,7 +380,7 @@ public class YSSegmentedControl: UIView {
             horizontalScrollViewConstrainingView.makeAttributesEqualToSuperview([.top])
             horizontalScrollViewConstrainingView.makeAttributesEqualToSuperview([.leading, .trailing])
         }
-        
+
         // Constrain all the items
         for (index, item) in items.enumerated() {
             item.translatesAutoresizingMaskIntoConstraints = false
@@ -394,7 +394,7 @@ public class YSSegmentedControl: UIView {
                     item.makeAttribute(.width, equalTo: UIScreen.main.bounds.width / CGFloat(viewState.titles.count))
                 }
             }
-                // Middle or last
+            // Middle or last
             else {
                 let previousItem = items[index - 1]
                 if viewState.shouldEvenlySpaceItemsHorizontally {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -382,6 +382,7 @@ public class YSSegmentedControl: UIView {
         }
 
         // Constrain all the items
+        var width = UIScreen.main.bounds.width
         for (index, item) in items.enumerated() {
             item.translatesAutoresizingMaskIntoConstraints = false
             
@@ -391,7 +392,7 @@ public class YSSegmentedControl: UIView {
             if index == 0 {
                 item.makeAttributesEqualToSuperview([.leading])
                 if viewState.shouldEvenlySpaceItemsHorizontally && !viewState.shouldSelectorBeSameWidthAsText {
-                    item.makeAttribute(.width, equalTo: UIScreen.main.bounds.width / CGFloat(viewState.titles.count))
+                    item.makeAttribute(.width, equalTo: width / CGFloat(viewState.titles.count))
                 }
             }
             // Middle or last
@@ -400,7 +401,7 @@ public class YSSegmentedControl: UIView {
                 if viewState.shouldEvenlySpaceItemsHorizontally {
                     if !viewState.shouldSelectorBeSameWidthAsText {
                         item.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
-                        item.makeAttribute(.width, equalTo: UIScreen.main.bounds.width / CGFloat(viewState.titles.count))
+                        item.makeAttribute(.width, equalTo: width / CGFloat(viewState.titles.count))
                     } else {
                         let newSpacerView = UIView()
                         newSpacerView.translatesAutoresizingMaskIntoConstraints = false

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -448,7 +448,8 @@ public class YSSegmentedControl: UIView {
     private func update(_ oldViewState: YSSegmentedControlViewState) {
         // If the number of titles have changed, re-add all of the items.
         if oldViewState.titles.count != viewState.titles.count ||
-            oldViewState.shouldEvenlySpaceItemsHorizontally != viewState.shouldEvenlySpaceItemsHorizontally {
+            oldViewState.shouldEvenlySpaceItemsHorizontally != viewState.shouldEvenlySpaceItemsHorizontally ||
+            oldViewState.shouldSelectorBeSameWidthAsText != viewState.shouldEvenlySpaceItemsHorizontally {
             
             // Remove all items
             removeItemsAndAssociatedViews()

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -143,6 +143,7 @@ class YSSegmentedControlItem: UIControl {
     }
     
     private func commonInit() {
+        label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
         

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -382,7 +382,7 @@ public class YSSegmentedControl: UIView {
         }
 
         // Constrain all the items
-        var width = UIScreen.main.bounds.width
+        var width = UIScreen.main.bounds.width / CGFloat(viewState.titles.count)
         for (index, item) in items.enumerated() {
             item.translatesAutoresizingMaskIntoConstraints = false
             
@@ -392,7 +392,7 @@ public class YSSegmentedControl: UIView {
             if index == 0 {
                 item.makeAttributesEqualToSuperview([.leading])
                 if viewState.shouldEvenlySpaceItemsHorizontally && !viewState.shouldSelectorBeSameWidthAsText {
-                    item.makeAttribute(.width, equalTo: width / CGFloat(viewState.titles.count))
+                    item.makeAttribute(.width, equalTo: width)
                 }
             }
             // Middle or last
@@ -402,7 +402,7 @@ public class YSSegmentedControl: UIView {
                 if viewState.shouldEvenlySpaceItemsHorizontally {
                     if !viewState.shouldSelectorBeSameWidthAsText {
                         item.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
-                        item.makeAttribute(.width, equalTo: width / CGFloat(viewState.titles.count))
+                        item.makeAttribute(.width, equalTo: width)
                     } else {
                         let newSpacerView = UIView()
                         newSpacerView.translatesAutoresizingMaskIntoConstraints = false

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -340,7 +340,7 @@ public class YSSegmentedControl: UIView {
         // Re-Add all items
         for _ in viewState.titles {
             let item = YSSegmentedControlItem(
-                frame: .zero,
+                frame: CGRect(x: 0, y: 0, width: 100, height: 44),
                 willPress: { [weak self] segmentedControlItem in
                     guard let weakSelf = self else {
                         return
@@ -363,7 +363,7 @@ public class YSSegmentedControl: UIView {
             scrollView.addSubview(item)
             items.append(item)
         }
-
+        
         if viewState.shouldEvenlySpaceItemsHorizontally {
             scrollView.addSubview(horizontalScrollViewConstrainingView)
             
@@ -380,7 +380,7 @@ public class YSSegmentedControl: UIView {
             horizontalScrollViewConstrainingView.makeAttributesEqualToSuperview([.top])
             horizontalScrollViewConstrainingView.makeAttributesEqualToSuperview([.leading, .trailing])
         }
-
+        
         // Constrain all the items
         for (index, item) in items.enumerated() {
             item.translatesAutoresizingMaskIntoConstraints = false
@@ -390,32 +390,40 @@ public class YSSegmentedControl: UIView {
             // First
             if index == 0 {
                 item.makeAttributesEqualToSuperview([.leading])
+                if viewState.shouldEvenlySpaceItemsHorizontally && !viewState.shouldSelectorBeSameWidthAsText {
+                    item.makeAttribute(.width, equalTo: UIScreen.main.bounds.width / CGFloat(viewState.titles.count))
+                }
             }
-            // Middle or last
+                // Middle or last
             else {
                 let previousItem = items[index - 1]
-                
                 if viewState.shouldEvenlySpaceItemsHorizontally {
-                    let newSpacerView = UIView()
-                    newSpacerView.translatesAutoresizingMaskIntoConstraints = false
-                    scrollView.addSubview(newSpacerView)
-                    spacerViews.append(newSpacerView)
-                    
-                    newSpacerView.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
-                    newSpacerView.makeAttribute(.trailing, equalToOtherView: item, attribute: .leading)
-                    _ = newSpacerView.makeConstraint(for: .height, equalTo: 0)
-                    newSpacerView.makeAttribute(.centerY, equalToOtherView: previousItem, attribute: .centerY)
-                    scrollView.addConstraint(NSLayoutConstraint(item: newSpacerView,
-                                                                attribute: .width,
-                                                                relatedBy: .greaterThanOrEqual,
-                                                                toItem: nil,
-                                                                attribute: .notAnAttribute,
-                                                                multiplier: 1.0,
-                                                                constant: 10))
-                    
-                    if spacerViews.count > 1 {
-                        let previousSpacerView = spacerViews[spacerViews.count - 2]
-                        newSpacerView.makeAttribute(.width, equalToOtherView: previousSpacerView, attribute: .width)
+                    if !viewState.shouldSelectorBeSameWidthAsText {
+                        item.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
+                        item.makeAttribute(.width, equalTo: UIScreen.main.bounds.width / CGFloat(viewState.titles.count))
+                    } else {
+                        let newSpacerView = UIView()
+                        newSpacerView.translatesAutoresizingMaskIntoConstraints = false
+                        scrollView.addSubview(newSpacerView)
+                        spacerViews.append(newSpacerView)
+                        
+                        newSpacerView.makeAttribute(.leading, equalToOtherView: previousItem, attribute: .trailing)
+                        newSpacerView.makeAttribute(.trailing, equalToOtherView: item, attribute: .leading)
+                        // _ = newSpacerView.makeConstraint(for: .height, equalTo: 0)
+                        newSpacerView.makeAttribute(.height, equalTo: 1)
+                        newSpacerView.makeAttribute(.centerY, equalToOtherView: previousItem, attribute: .centerY)
+                        scrollView.addConstraint(NSLayoutConstraint(item: newSpacerView,
+                                                                    attribute: .width,
+                                                                    relatedBy: .greaterThanOrEqual,
+                                                                    toItem: nil,
+                                                                    attribute: .notAnAttribute,
+                                                                    multiplier: 1.0,
+                                                                    constant: 10))
+                        
+                        if spacerViews.count > 1 {
+                            let previousSpacerView = spacerViews[spacerViews.count - 2]
+                            newSpacerView.makeAttribute(.width, equalToOtherView: previousSpacerView, attribute: .width)
+                        }
                     }
                 }
                 else {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -56,6 +56,12 @@ public struct YSSegmentedControlViewState {
     public var shouldEvenlySpaceItemsHorizontally: Bool
     
     /**
+     Whether or not the selector should be the same size as the item text,
+     or a proportion of the screen
+     */
+    public var shouldSelectorBeSameWidthAsText: Bool
+    
+    /**
      The titles that show inside the segmented control.
      */
     public var titles: [String]
@@ -73,6 +79,7 @@ public struct YSSegmentedControlViewState {
         selectorOffsetFromLabel = nil
         offsetBetweenTitles = 48
         shouldEvenlySpaceItemsHorizontally = false
+        shouldSelectorBeSameWidthAsText = false
         titles = []
     }
 }


### PR DESCRIPTION
## Description

This PR will bring back the functionality of items being a calculated proportion, as well as the width of it's title.

## Note
This PR only handles the functionality of the `segmentedcontrol` there is no update to the UI in this PR to allow you to update the `viewState` based on `shouldSelectorBeSameWidthAsText`. This is also why the image below doesn't look 100% correct. This is also why I use `UIScreen.main.bounds.width` instead of a the controls frame (this gets updated in https://github.com/stockx/YSSegmentedControl/pull/10).

<img width="584" alt="screen shot 2018-07-13 at 11 10 17 am" src="https://user-images.githubusercontent.com/22037563/42698942-5aab0b82-868d-11e8-9386-625de58b87f3.png">